### PR TITLE
New syncing, Added German translation

### DIFF
--- a/lua/terrortown/autorun/server/sv_swapper_helper.lua
+++ b/lua/terrortown/autorun/server/sv_swapper_helper.lua
@@ -1,5 +1,5 @@
-function roles.SWAPPER.GetRespawnRole(killer)
-	if GetConVar("ttt2_swapper_respawn_opposite_team"):GetBool() then
+function roles.SWAPPER.GetRespawnRole(killer, opposite)
+	if opposite then
 		local rd = killer:GetSubRoleData()
 		local selectablePlys = roleselection.GetSelectablePlayers(player.GetAll())
 		local reviveRoleCandidates = table.Copy(roleselection.GetAllSelectableRolesList(#selectablePlys))
@@ -9,8 +9,10 @@ function roles.SWAPPER.GetRespawnRole(killer)
 		reviveRoleCandidates[ROLE_INNOCENT] = reviveRoleCandidates[ROLE_INNOCENT] or 1
 		reviveRoleCandidates[ROLE_TRAITOR] = reviveRoleCandidates[ROLE_TRAITOR] or 1
 
-		--remove jester from the revive candidate roles
+		--remove jester like roles from the revive candidate roles
 		reviveRoleCandidates[ROLE_JESTER] = nil
+		reviveRoleCandidates[ROLE_BEGGAR] = nil
+		reviveRoleCandidates[ROLE_CLOWN] = nil
 
 		for k in pairs(reviveRoleCandidates) do
 			local roleData = roles.GetByIndex(k)

--- a/lua/terrortown/entities/roles/swapper/shared.lua
+++ b/lua/terrortown/entities/roles/swapper/shared.lua
@@ -8,8 +8,9 @@ function ROLE:PreInitialize()
 	self.color = Color(214, 47, 125, 255)
 
 	self.abbr = "swa"
-	self.score.surviveBonusMultiplier = -2
-	self.score.timelimitMultiplier = -2
+	self.score.surviveBonusMultiplier = 0
+	self.score.survivePenaltyMultiplier = -4
+	self.score.timelimitMultiplier = -4
 	self.score.killsMultiplier = 0
 	self.score.teamKillsMultiplier = -16
 	self.score.bodyFoundMuliplier = 0

--- a/lua/terrortown/entities/roles/swapper/shared.lua
+++ b/lua/terrortown/entities/roles/swapper/shared.lua
@@ -173,6 +173,8 @@ if SERVER then
 			-- Handle the killers swap to his new life of swapper
 			attacker:SetRole(ROLE_SWAPPER)
 
+			SendFullStateUpdate()
+
 			local health = GetConVar("ttt2_swapper_killer_health"):GetInt()
 
 			if health <= 0 then

--- a/lua/terrortown/entities/roles/swapper/shared.lua
+++ b/lua/terrortown/entities/roles/swapper/shared.lua
@@ -9,6 +9,7 @@ function ROLE:PreInitialize()
 
 	self.abbr = "swa"
 	self.score.surviveBonusMultiplier = 0
+	self.score.aliveTeammatesBonusMultiplier = 0
 	self.score.survivePenaltyMultiplier = -4
 	self.score.timelimitMultiplier = -4
 	self.score.killsMultiplier = 0

--- a/lua/terrortown/lang/de/swapper.lua
+++ b/lua/terrortown/lang/de/swapper.lua
@@ -1,0 +1,11 @@
+local L = LANG.GetLanguageTableReference("de")
+
+-- GENERAL ROLE LANGUAGE STRINGS
+L[SWAPPER.name] = "Wechsler"
+L["info_popup_" .. SWAPPER.name] = [[Du bist der Wechsler. Versuche zu sterben]]
+L["body_found_" .. SWAPPER.abbr] = "Er war ein Wechsler!"
+L["search_role_" .. SWAPPER.abbr] = "Diese Person war ein Wechsler!"
+L["target_" .. SWAPPER.name] = "Wechsler"
+L["ttt2_desc_" .. SWAPPER.name] = [[Der Wechsler ist eine Gauklerrolle, welche ihrem Mörder die Identität stielt. Der Mörder wird dann zum neuen Wechsler!]]
+
+-- OTHER ROLE LANGUAGE STRINGS

--- a/lua/terrortown/lang/de/swapper.lua
+++ b/lua/terrortown/lang/de/swapper.lua
@@ -1,11 +1,11 @@
 local L = LANG.GetLanguageTableReference("de")
 
 -- GENERAL ROLE LANGUAGE STRINGS
-L[SWAPPER.name] = "Wechsler"
-L["info_popup_" .. SWAPPER.name] = [[Du bist der Wechsler. Versuche zu sterben]]
-L["body_found_" .. SWAPPER.abbr] = "Er war ein Wechsler!"
-L["search_role_" .. SWAPPER.abbr] = "Diese Person war ein Wechsler!"
-L["target_" .. SWAPPER.name] = "Wechsler"
-L["ttt2_desc_" .. SWAPPER.name] = [[Der Wechsler ist eine Gauklerrolle, welche ihrem Mörder die Identität stielt. Der Mörder wird dann zum neuen Wechsler!]]
+L[roles.SWAPPER.name] = "Wechsler"
+L["info_popup_" .. roles.SWAPPER.name] = [[Du bist der Wechsler. Versuche zu sterben]]
+L["body_found_" .. roles.SWAPPER.abbr] = "Er war ein Wechsler!"
+L["search_role_" .. roles.SWAPPER.abbr] = "Diese Person war ein Wechsler!"
+L["target_" .. roles.SWAPPER.name] = "Wechsler"
+L["ttt2_desc_" .. roles.SWAPPER.name] = [[Der Wechsler ist eine Gauklerrolle, welche ihrem Mörder die Identität stielt. Der Mörder wird dann zum neuen Wechsler!]]
 
 -- OTHER ROLE LANGUAGE STRINGS

--- a/lua/terrortown/lang/en/swapper.lua
+++ b/lua/terrortown/lang/en/swapper.lua
@@ -11,5 +11,5 @@ L["ttt2_desc_" .. roles.SWAPPER.name] = [[The swapper is a Jester role that will
 -- OTHER ROLE LANGUAGE STRINGS
 L["ttt2_role_swapper_inform_opposite"] = "You'll respawn as a random opposite role of your killer this round!"
 L["ttt2_role_swapper_inform_same"] = "You'll respawn as the same role as your killer this round!"
-L["ttt2_role_swapper_inform_wait"] = "You'll only respawn once your killer dies this round!"
+L["ttt2_role_swapper_inform_wait"] = "You wont respawn until your killer dies this round!"
 L["ttt2_role_swapper_inform_instant"] = "You'll respawn after {delay} seconds once killed this round!"

--- a/lua/terrortown/lang/en/swapper.lua
+++ b/lua/terrortown/lang/en/swapper.lua
@@ -9,3 +9,7 @@ L["target_" .. roles.SWAPPER.name] = "Swapper"
 L["ttt2_desc_" .. roles.SWAPPER.name] = [[The swapper is a Jester role that will steal its killers identity when killed and resurrect their killer as the new swapper!]]
 
 -- OTHER ROLE LANGUAGE STRINGS
+L["ttt2_role_swapper_inform_opposite"] = "You'll respawn as a random opposite role of your killer this round!"
+L["ttt2_role_swapper_inform_same"] = "You'll respawn as the same role as your killer this round!"
+L["ttt2_role_swapper_inform_wait"] = "You'll only respawn once your killer dies this round!"
+L["ttt2_role_swapper_inform_instant"] = "You'll respawn after {delay} seconds once killed this round!"

--- a/lua/terrortown/lang/en/swapper.lua
+++ b/lua/terrortown/lang/en/swapper.lua
@@ -1,11 +1,11 @@
 local L = LANG.GetLanguageTableReference("en")
 
 -- GENERAL ROLE LANGUAGE STRINGS
-L[SWAPPER.name] = "Swapper"
-L["info_popup_" .. SWAPPER.name] = [[You are the swapper, now go get killed!]]
-L["body_found_" .. SWAPPER.abbr] = "They were a Swapper!?"
-L["search_role_" .. SWAPPER.abbr] = "This person was a Swapper!?"
-L["target_" .. SWAPPER.name] = "Swapper"
-L["ttt2_desc_" .. SWAPPER.name] = [[The swapper is a Jester role that will steal its killers identity when killed and resurrect their killer as the new swapper!]]
+L[roles.SWAPPER.name] = "Swapper"
+L["info_popup_" .. roles.SWAPPER.name] = [[You are the swapper, now go get killed!]]
+L["body_found_" .. roles.SWAPPER.abbr] = "They were a Swapper!?"
+L["search_role_" .. roles.SWAPPER.abbr] = "This person was a Swapper!?"
+L["target_" .. roles.SWAPPER.name] = "Swapper"
+L["ttt2_desc_" .. roles.SWAPPER.name] = [[The swapper is a Jester role that will steal its killers identity when killed and resurrect their killer as the new swapper!]]
 
 -- OTHER ROLE LANGUAGE STRINGS


### PR DESCRIPTION
I'm here with a new pullrequest!

- all players from the team jester are now shown by default, you can remove this with the `TTT2JesterModifyList` hook
![image](https://user-images.githubusercontent.com/13639408/136182458-a88d8411-a902-4d97-99c4-80da13be74f2.png)
- the swapper now works with the newly introduced custom role syncing of the jester, it therefore no longer needs its own syncing
- the swapper still hides as a normal jester with the help of a new hook
![image](https://user-images.githubusercontent.com/13639408/136182636-2c9bb880-f17c-4397-87b5-22cfa34e5db8.png)
- I changed the swapper color slighty
- I added a German translation
- I fixed your scroing variables, you seem to have used a very old format; I set them to the jester values, feel free to change them (my chosen values don't reward kills and punish surviving a round)

EDIT: There seems to be a scoring bug in TTT2, because the jester and the swapper are not punished for surviving right now

EDIT2: Fixed the scroing problem by introducing a new scoring varibale. I set it here to -4, which means that you'll get -4 points for every teammate alive at the end of the round.
![image](https://user-images.githubusercontent.com/13639408/136185063-ee62ead0-2267-4d64-b1e0-5c1ec03b0e1f.png)


Please release this AFTER I updated the jester, since it heavily relies on the completely reworked jester. However this will happen today most likely. I tested it, but please verify that everything works to your expectations.